### PR TITLE
[翻译完毕] 23-作用域内资源用法

### DIFF
--- a/23-scoped-resource-usage.md
+++ b/23-scoped-resource-usage.md
@@ -1,4 +1,4 @@
-Kotlin does not have Python's _resource managers_ or Java's _try-with-resources_, but thanks to extension functions, there's `use`:
+Kotlin 没有 Python 的 _资源管理器(resource managers)_ 或 Java 的 _try-with-resources_，但是多亏了扩展函数，有了 `use`：
 
 ```kotlin
 File("/home/aasmund/test.txt").inputStream().use {
@@ -7,11 +7,11 @@ File("/home/aasmund/test.txt").inputStream().use {
 }
 ```
 
-`use` can be invoked on anything that implements the `Closeable` interface, and when the `use` block ends (whether normally or due to an exception), `close()` will be called on the object upon which you invoked `use`. If an exception is raised within the block or by `close()`, it will bubble out of `use`. If both the block and `close()` raise, it's the exception from the block that will bubble out.
+可以在实现 `Closeable` 接口的任何对象上调用 `use`，并且当 `use` 块结束时（无论是正常还是引发异常），都会在调用 `use` 的对象上调用 `close()`。如果在该代码块内或通过 `close()` 引发了异常，那么该异常将冒泡并退出 `use` 。如果代码块与 `close()` 都提升了，那么来自代码块的异常就会冒泡。
 
-Thus, you can create something resource manager-like by creating a class that implements `Closeable`, does its setup work in `init`, and does its cleanup work in `close()`.
+因此，可以创建类似于资源管理器的东西，方法是创建一个实现 `Closeable` 的类，在 `init` 中进行设置工作，在 `close()` 中进行清理工作。
 
-In case you're wondering about how `use`, which is a function, can just be followed by a block like that, see the section on [DSL support](functional-programming.html#接收者).
+如果想知道如何“`use`”，它是一个函数，后面可以跟着一个这样的代码块，请参见 [DSL 支持](functional-programming.html#接收者)一节。
 
 
 

--- a/README.md
+++ b/README.md
@@ -2346,7 +2346,7 @@ File("data.txt").writeText("Hello world!")
 
 ## 作用域内资源用法
 
-Kotlin does not have Python's _resource managers_ or Java's _try-with-resources_, but thanks to extension functions, there's `use`:
+Kotlin 没有 Python 的 _资源管理器(resource managers)_ 或 Java 的 _try-with-resources_，但是多亏了扩展函数，有了 `use`：
 
 ```kotlin
 File("/home/aasmund/test.txt").inputStream().use {
@@ -2355,11 +2355,11 @@ File("/home/aasmund/test.txt").inputStream().use {
 }
 ```
 
-`use` can be invoked on anything that implements the `Closeable` interface, and when the `use` block ends (whether normally or due to an exception), `close()` will be called on the object upon which you invoked `use`. If an exception is raised within the block or by `close()`, it will bubble out of `use`. If both the block and `close()` raise, it's the exception from the block that will bubble out.
+可以在实现 `Closeable` 接口的任何对象上调用 `use`，并且当 `use` 块结束时（无论是正常还是引发异常），都会在调用 `use` 的对象上调用 `close()`。如果在该代码块内或通过 `close()` 引发了异常，那么该异常将冒泡并退出 `use` 。如果代码块与 `close()` 都提升了，那么来自代码块的异常就会冒泡。
 
-Thus, you can create something resource manager-like by creating a class that implements `Closeable`, does its setup work in `init`, and does its cleanup work in `close()`.
+因此，可以创建类似于资源管理器的东西，方法是创建一个实现 `Closeable` 的类，在 `init` 中进行设置工作，在 `close()` 中进行清理工作。
 
-In case you're wondering about how `use`, which is a function, can just be followed by a block like that, see the section on [DSL support](#接收者).
+如果想知道如何“`use`”，它是一个函数，后面可以跟着一个这样的代码块，请参见 [DSL 支持](#接收者)一节。
 
 
 ## 编写文档


### PR DESCRIPTION
<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [ ] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [ ] 阅读过 Kotlin 参考的大部分章节
- [ ] 每一句都已经过谷歌机翻作为参考
- [ ] 每一句都已经过搜狗机翻作为参考
- [ ] 翻译中所用术语均与术语表中一致
- [ ] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [ ] 正文与注释中的标点均已使用全角
- [ ] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [ ] 英文与标点之间未留空格
- [ ] 行级对照，中文句子中间断行处已使用 HTML 注释
