### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1370,7 +1370,7 @@ maybeNull?.apply {
 }?.memberFunctionB()
 ```
 
-在 `apply` 块中，`this 是指 `maybeNull`。在 `memberPropertyA`，`memberPropertyB` 与 `memberFunctionA` 之前有一个隐含的 `this`（除非这些在 `maybeNull` 上不存在，在这种情况下将在包含的作用域中查找它们）。此后，也可以在 `maybeNull` 上调用 `memberFunctionB()`。
+在 `apply` 块中，`this` 是指 `maybeNull`。在 `memberPropertyA`，`memberPropertyB` 与 `memberFunctionA` 之前有一个隐含的 `this`（除非这些在 `maybeNull` 上不存在，在这种情况下将在包含的作用域中查找它们）。此后，也可以在 `maybeNull` 上调用 `memberFunctionB()`。
 
 如果发现 `this` 语法令人困惑，那么可以改用 `also`，它以普通的 lambda 作为参数：
 


### PR DESCRIPTION
Origin: https://github.com/Khan/kotlin-for-python-developers/blob/master/README.md#apply-and-also

---

<!--
感谢你的贡献！
如果只是修正格式、错别字请忽略以下这段。如果提交翻译 PR（Pull Request），为了统一风格、提升质量、便于维护，请务必细看以下说明：
---
目前《翻译指南》还在制订中，不过在 [kotlin-web-site-cn#35](https://github.com/hltj/kotlin-web-site-cn/issues/35) 中有一部分草稿版。
如果初次翻译，请确保提 PR 前你已经读过 #35 以及其中的链接，并且已按照这些地方的说明来修改原稿。

以下是 checklist，请在发起 PR 时认真填写（完成项在 [ ] 内将空格替换为 X）。
为避免重复劳动（确实对有些贡献者的翻译进行校对的过程如同重新翻译一遍……），如有多项未完成则不予合并，还请理解与配合。
-->
- [x] 已仔细阅读 kotlin-web-site-cn#⁠35 及其中链接的内容
- [x] 阅读过 Kotlin 参考的大部分章节
- [x] 每一句都已经过谷歌机翻作为参考
- [x] 每一句都已经过搜狗机翻作为参考
- [x] 翻译中所用术语均与术语表中一致
- [x] 注释也已翻译，除了 `//sampleStart` 与 `//sampleEnd`
- [x] 正文与注释中的标点均已使用全角
- [x] 中文与英文/数字之间、中文与 `` ` `` 之间都以空格分隔
- [x] 英文与标点之间未留空格
- [x] 行级对照，中文句子中间断行处已使用 HTML 注释
